### PR TITLE
add support for external data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ __Features:__
 - Keyboard navigation
 - Checkboxes (auto / manual)
 - Drag and drop
-- Custmizable style
+- Customizable style
 - Customizable icons
 
 ## Installation

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -31,10 +31,13 @@ Try events yourself (go check the console with F12)
 ## Context
 Drag context, is composed of dragged element and target element which are both "IDragContext"
 
-| Variable | Type                          | Description     |
-|----------|-------------------------------|-----------------|
-| dragged  | [IDragContext](#idragcontext) | Dragged context |
-| target   | [IDragContext](#idragcontext) | Target context  |
+| Variable     | Type                          | Description                        |
+|--------------|-------------------------------|------------------------------------|
+| dragged      | [IDragContext](#idragcontext) | Dragged context                    |
+| target       | [IDragContext](#idragcontext) | Target context                     |
+| evt          | DragEvent                     | Drag Event                         |
+| external     | Boolean                       | Determine if the node is external  |
+| dataTransfer | Object | String | null        | Event dataTransfer content         |
 
 ::: warning
 In function of the drag event, target may be null

--- a/src/dev.vue
+++ b/src/dev.vue
@@ -55,23 +55,28 @@
     ref="Tree"
     :nodes="nodes"
     :config="config"
-    
+
     @node-opened="log(`node-opened`)"
     @node-closed="log('node-closed')"
     @node-focus="log('node-focus')"
     @node-toggle="log('node-toggle')"
     @node-blur="log('node-blur')"
     @node-edit="log('node-edit')"
-    
+
     @node-checked="log('node-checked')"
     @node-unchecked="log('node-unchecked')"
-    
+
     @node-dragstart="log('node-dragstart')"
     @node-dragenter="log('node-dragenter')"
     @node-dragleave="log('node-dragleave')"
     @node-dragend="log('node-dragend')"
     @node-over="log('node-over')"
     @node-drop="log('node-drop')"
+
+    @node-drop-ext="log('drop-ext')"
+    @node-over-ext="log('over-ext')"
+    @node-dragenter-ext="log('dragenter-ext')"
+    @node-dragleave-ext="log('dragleave-ext')"
   >
     <!--template #loading-slot>
       <div class="load">
@@ -114,6 +119,16 @@
       Generate random tree
     </button>
   </p>
+  <span>External items</span>
+  <ul>
+    <li
+      v-for="item in extItems"
+      :key="item.title"
+      @dragstart="startDragExt($event, item)"
+    >
+      {{ item.title }}
+    </li>
+  </ul>
 </template>
 
 <script lang="ts">
@@ -134,7 +149,7 @@ export default {
         checkboxes: true,
         dragAndDrop: false,
         checkMode: checkMode.manual,
-        keyboardNavigation: false,        
+        keyboardNavigation: false,
       },
       nodes: {},
       modeBool: false,
@@ -142,7 +157,12 @@ export default {
       nbRoots: 0,
       maxDepth: 0,
       maxChild: 0,
-      nbNodes: 0
+      nbNodes: 0,
+      extItems:  [
+          { id: 0, title: 'Item A' },
+          { id: 1, title: 'Item B' },
+          { id: 2, title: 'Item C' }
+      ]
     };
   },
   mounted() {
@@ -212,6 +232,10 @@ export default {
     log(s: string): void {
       console.log(s);
     },
+    startDragExt (evt, item) {
+        evt.dataTransfer!.setData('application/json', JSON.stringify(item));
+        // evt.dataTransfer!.setData('text/plain', "some content");
+    },
     serverLoading(node: INode): void {
       if (node.children == null || node.children.length === 0) {
         node.state.isLoading = true;
@@ -248,7 +272,7 @@ export default {
       }
 
       console.log(`node created: ${this.nbNodes}`);
-      console.log(this.nodes);      
+      console.log(this.nodes);
     },
     addNodes(parent: INode, lvl: number, depth: number): void {
       for (let i = 0; i < this.maxChild; i++) {
@@ -258,7 +282,7 @@ export default {
 
         const n = this.createNode(Number(`${lvl}${i + 1}`), depth);
         parent.children.push(n);
-      }      
+      }
     },
     createNode(lvl: number, depth: number): string {
       const id = `id${ lvl }`;
@@ -275,7 +299,7 @@ export default {
         this.addNodes(n, lvl, depth - 1);
       }
 
-      return id;      
+      return id;
     },
     randomState(): INodeState {
       return {

--- a/src/dev.vue
+++ b/src/dev.vue
@@ -124,6 +124,7 @@
     <li
       v-for="item in extItems"
       :key="item.title"
+      draggable="true"
       @dragstart="startDragExt($event, item)"
     >
       {{ item.title }}

--- a/src/dev.vue
+++ b/src/dev.vue
@@ -72,11 +72,6 @@
     @node-dragend="log('node-dragend')"
     @node-over="log('node-over')"
     @node-drop="log('node-drop')"
-
-    @node-drop-ext="log('drop-ext')"
-    @node-over-ext="log('over-ext')"
-    @node-dragenter-ext="log('dragenter-ext')"
-    @node-dragleave-ext="log('dragleave-ext')"
   >
     <!--template #loading-slot>
       <div class="load">

--- a/src/misc/nodeEvents.ts
+++ b/src/misc/nodeEvents.ts
@@ -18,5 +18,11 @@ export const dragEvents = {
     enter: "nodeDragenter",
     leave: "nodeDragleave",
     over: "nodeOver",
-    drop: "nodeDrop"
+    drop: "nodeDrop",
+
+    // Events from external source
+    enterExt: "nodeDragenterExt",
+    leaveExt: "nodeDragleaveExt",
+    overExt: "nodeOverExt",
+    dropExt: "nodeDropExt"
 };

--- a/src/misc/nodeEvents.ts
+++ b/src/misc/nodeEvents.ts
@@ -18,11 +18,5 @@ export const dragEvents = {
     enter: "nodeDragenter",
     leave: "nodeDragleave",
     over: "nodeOver",
-    drop: "nodeDrop",
-
-    // Events from external source
-    enterExt: "nodeDragenterExt",
-    leaveExt: "nodeDragleaveExt",
-    overExt: "nodeOverExt",
-    dropExt: "nodeDropExt"
+    drop: "nodeDrop"
 };

--- a/src/setup/useDragAndDrop.ts
+++ b/src/setup/useDragAndDrop.ts
@@ -98,14 +98,14 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
     });
 
     const getDataTransfer = (evt: DragEvent) : string | object | null => {
-        if (!evt.dataTransfer) return null;
+        if (!evt || !evt.dataTransfer) return null;
         const jsonPayload = evt.dataTransfer.getData("application/json");
         if (jsonPayload)  return JSON.parse(jsonPayload);
         return evt.dataTransfer.getData("text/plain");
     };
 
     const isExternalSrc = (evt: DragEvent) : boolean => {
-        return evt.dataTransfer?.items?.length > 0;
+        return evt?.dataTransfer?.items?.length > 0;
     };
 
     const dragstart = (evt: DragEvent): void => {

--- a/src/setup/useDragAndDrop.ts
+++ b/src/setup/useDragAndDrop.ts
@@ -116,21 +116,29 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
                 wrapper: wrapper.value,
                 parentId: parentId.value
             };
-            cmn.root.emit(dragEvents.start, context.value);
+            cmn.root.emit(dragEvents.start, {...context.value, ...eventContext(evt)});
         }
     };
 
+    const eventContext = (evt: DragEvent) => {
+        return {
+            evt,
+            external: isExternalSrc(evt),
+            dataTransfer: getDataTransfer(evt)
+        }
+    }
+
     const dragend = (evt: DragEvent): void => {
-        cmn.root.emit(dragEvents.end, context.value);
+        cmn.root.emit(dragEvents.end, {...context.value, ...eventContext(evt)});
         dragged.value = null;
     };
 
     const dragenter = (evt: DragEvent): void => {
-        cmn.root.emit(dragEvents.enter, {...context.value, external: isExternalSrc(evt), evt});
+        cmn.root.emit(dragEvents.enter, {...context.value, ...eventContext(evt)});
     };
 
     const dragleave = (evt: DragEvent): void => {
-        cmn.root.emit(dragEvents.leave, {...context.value, external: isExternalSrc(evt), evt});
+        cmn.root.emit(dragEvents.leave, {...context.value, ...eventContext(evt)});
         pos.value = null;
     };
 
@@ -139,7 +147,7 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
             const external = isExternalSrc(evt);
             if (!isDragging.value && !external) return;
 
-            cmn.root.emit(dragEvents.over, {...context.value, external, evt});
+            cmn.root.emit(dragEvents.over, {...context.value, ...eventContext(evt)});
 
             if (!external && wrapper.value) {
                 const factor = .3;
@@ -170,7 +178,7 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
     };
 
     const drop = (evt: DragEvent): void => {
-        cmn.root.emit(dragEvents.drop, {...context.value, external: isExternalSrc(evt), evt, dataTransfer: getDataTransfer(evt)});
+        cmn.root.emit(dragEvents.drop, {...context.value, ...eventContext(evt)});
 
         if (!isSameNode.value && !dragContain.value) {
             switch(pos.value) {

--- a/src/setup/useDragAndDrop.ts
+++ b/src/setup/useDragAndDrop.ts
@@ -97,6 +97,17 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
         return !isNil(node) ? node.children : config.value.roots;
     });
 
+    const getExternalPayload = (evt: DragEvent) : string | object | null => {
+        if (!evt.dataTransfer) return null;
+        const jsonPayload = evt.dataTransfer.getData("application/json");
+        if (jsonPayload)  return JSON.parse(jsonPayload);
+        return evt.dataTransfer.getData("text/plain");
+    };
+
+    const isExternalSrc = (evt: DragEvent) : boolean => {
+        return evt.dataTransfer?.items?.length > 0;
+    };
+
     const dragstart = (evt: DragEvent): void => {
         if (draggable.value) {
             dragged.value = {
@@ -116,11 +127,13 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
 
     const dragenter = (evt: DragEvent): void => {
         cmn.root.emit(dragEvents.enter, context.value);
+        if (isExternalSrc(evt)) cmn.root.emit(dragEvents.enterExt, {...context.value, evt});
     };
 
     const dragleave = (evt: DragEvent): void => {
         cmn.root.emit(dragEvents.leave, context.value);
         pos.value = null;
+        if (isExternalSrc(evt)) cmn.root.emit(dragEvents.leaveExt, {...context.value, evt});
     };
 
     const dragover = (evt: DragEvent): void => {
@@ -153,6 +166,7 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
                 }
             }
         }
+        if (isExternalSrc(evt)) cmn.root.emit(dragEvents.overExt, {...context.value, evt});
     };
 
     const drop = (evt: DragEvent): void => {
@@ -176,6 +190,7 @@ export default function useDragAndDrop(cmn: IUseCommon, props: INodeProps): {} {
         }
 
         pos.value = null;
+        if (isExternalSrc(evt)) cmn.root.emit(dragEvents.dropExt, {...context.value, evt, payload: getExternalPayload(evt)});
     };
 
     const insertAt = (i: 0 | 1) => {

--- a/tests/unit/useDragAndDrop.spec.ts
+++ b/tests/unit/useDragAndDrop.spec.ts
@@ -108,8 +108,11 @@ describe("test use Drag and Drop", () => {
             wrapper: wrapper.value
         };
         fakeContext = {
+            dataTransfer: null,
             dragged: fakeDragged,
-            target: fakeTarget
+            target: fakeTarget,
+            evt: undefined,
+            external: false
         };        
         props = {
             parentId: ref(null)


### PR DESCRIPTION
Hello,

This PR triggers the following events when items are dropped from an external source:
 -   @node-drop-ext
 -   @node-over-ext
 -   @node-dragenter-ext
 -   @node-dragleave-ext

Would it be possible to create a new npm version once this PR is merged?

Thx!